### PR TITLE
Avoid unavailable native values for sensors

### DIFF
--- a/custom_components/attribute_as_sensor/sensor.py
+++ b/custom_components/attribute_as_sensor/sensor.py
@@ -141,17 +141,18 @@ class AttributeSensor(SensorEntity):
         new_state: State | None = event.data.get("new_state")
         _LOGGER.debug("Received new state: %s", new_state)
 
-        self._attr_available = new_state != STATE_UNAVAILABLE
-
         self._attr_native_value = None
-        if (
-            new_state is None
-            or new_state.state is None
-            or new_state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]
-        ):
+        self._attr_available = (
+            new_state is not None
+            and new_state.state is not None
+            and new_state.state not in [STATE_UNAVAILABLE, STATE_UNKNOWN]
+        )
+        if not self._attr_available:
             if not update_state:
                 _LOGGER.debug("Ignoring state update")
                 return
+            self.async_write_ha_state()
+            return
 
         if self._attribute not in new_state.attributes:
             if not self._has_logged:
@@ -161,7 +162,7 @@ class AttributeSensor(SensorEntity):
                     self._entity_id,
                 )
             self._has_logged = True
-            self._attr_native_value = STATE_UNAVAILABLE
+            self._attr_available = False
             self.async_write_ha_state()
             return
 


### PR DESCRIPTION
## Summary

Avoid setting the string `unavailable` as the native value for an Attribute as Sensor sensor when the source entity is unavailable or the selected attribute is missing.

Instead, mark the sensor unavailable and keep `_attr_native_value` as `None`.

## Why

For sensors configured with numeric metadata, such as `device_class`, `state_class`, and `unit_of_measurement`, Home Assistant expects the native value to be numeric or `None`.

When the current code assigns `STATE_UNAVAILABLE` to `_attr_native_value`, Home Assistant can log warnings like:

```text
Bad logger message: Sensor sensor.temperatura_ingresso has device class 'temperature', state class 'measurement' unit '°C' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: 'unavailable' (<class 'str'>)
```

I reproduced this with a sensor exposing a Netatmo climate entity's `current_temperature` attribute. When the source entity/attribute was temporarily unavailable, the helper sensor was still treated as a numeric temperature sensor but received the string `unavailable` as its native value.

## Change

- Treat `None`, `unknown`, and `unavailable` source states as unavailable sensor state.
- Treat a missing selected attribute as unavailable sensor state.
- Do not assign `STATE_UNAVAILABLE` to `_attr_native_value`.

## Testing

- Ran `python3 -m py_compile custom_components/attribute_as_sensor/sensor.py`.
- Applied the same change locally on a Home Assistant 2026.5.4 instance and verified Home Assistant config check passes.
